### PR TITLE
added conditional to hide silver sponsor if none are present

### DIFF
--- a/webs/src/components/Sponsors/Sponsors.js
+++ b/webs/src/components/Sponsors/Sponsors.js
@@ -71,6 +71,7 @@ const Sponsors = () => {
           </Col>
         ))}
       </Row>
+      {silverSponsor.length > 0 && (
       <Row className="d-flex justify-content-center align-items-center text-center">
         <h3>Silver Sponsor</h3>
         {silverSponsor.map((node, index) => (
@@ -90,6 +91,7 @@ const Sponsors = () => {
           </Col>
         ))}
       </Row>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
added {silverSponsor.length > 0 && ()} - If there are no silver sponsors then return nothing, but if there are silver sponsors the the entire row block is displayed. 